### PR TITLE
Fix type checking of library with mypy

### DIFF
--- a/__version__.py
+++ b/__version__.py
@@ -1,2 +1,2 @@
 version = 0
-revision = 5
+revision = 6

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ description = Check code against coding style standards
 deps =
     autopep8
     isort
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-builtins
     pyproject-flake8


### PR DESCRIPTION
`compound_status.py` was not passing type checking when imported in a charm that uses mypy. This PR fixes those errors and lets users type check their project while using this library.